### PR TITLE
Need poststart hooks for all images to copy the default plugins

### DIFF
--- a/public-access/supported_images.json
+++ b/public-access/supported_images.json
@@ -3,8 +3,11 @@
       "description": "The underworld community (v2.8 test release)",
       "imagename": "lmoresi/uw_on_the_uw_user_cloud:2019.07.25_dev",
       "notebook_dir": "/user_data/Underworld",
-      "default_url": "LandingPage.md",
-      "poststart": null,
+      "default_url": "/lab/LandingPage.md",
+      "poststart": [
+          "python3",
+          "/user_data/scripts/install_user_files.py"
+      ],
       "cmd": [
           "jupyter-labhub"
       ],


### PR DESCRIPTION
Persistent storage needs to be initialised regardless of image. 